### PR TITLE
增加 valid 参数用于自定义 has 验证

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ exports.cache = {
       password: '',
       db: 0,
       ttl: 600,
+      valid: _ => _ !== null,
     },
   },
 };
@@ -141,7 +142,10 @@ exports.cache = {
 const store = app.cache.store('redis');
 
 await store.set('foo', 'bar');
-await store.get('foo'); // bar
+await store.get('foo'); // 'bar'
+
+await store.del('foo');
+await store.has('foo'); // false
 ```
 
 ### Api

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -127,6 +127,7 @@ exports.cache = {
       password: '',
       db: 0,
       ttl: 600,
+      valid: _ => _ !== null,
     },
   },
 };
@@ -138,7 +139,10 @@ exports.cache = {
 const store = app.cache.store('redis');
 
 await store.set('foo', 'bar');
-await store.get('foo'); // bar
+await store.get('foo'); // 'bar'
+
+await store.del('foo');
+await store.has('foo'); // false
 ```
 
 ### Api

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -19,11 +19,12 @@ module.exports = app => {
 
       options = Object.assign({
         store: config.driver,
+        valid: _ => _ !== undefined,
       }, stores[name], options);
 
       const driver = manager.caching(options);
 
-      drivers[name] = new Store(driver);
+      drivers[name] = new Store(driver, options);
     }
 
     return drivers[name];

--- a/lib/store.js
+++ b/lib/store.js
@@ -2,11 +2,9 @@
 
 class Store {
 
-  /**
-   * @param {Object} driver Cache Manager Store
-   */
-  constructor(driver) {
+  constructor(driver, options) {
     this.driver = driver;
+    this.options = options;
   }
 
   set(name, value, expire = null, options = null) {
@@ -40,7 +38,7 @@ class Store {
   }
 
   has(name) {
-    return this.driver.get(name).then(value => value !== undefined);
+    return this.driver.get(name).then(this.options.valid);
   }
 
   reset() {

--- a/lib/store.js
+++ b/lib/store.js
@@ -21,7 +21,7 @@ class Store {
 
   get(name, defaultValue = null, expire = null, options = null) {
     return this.driver.get(name).then(value => {
-      if (value !== undefined) {
+      if (this.options.valid(value)) {
         return value;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-cache",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Cache plugin for Egg",
   "eggPlugin": {
     "name": "cache"


### PR DESCRIPTION
cache-manager 的不同 store 在不存在缓存时返回的结果不一致。
目前已知的：

memory:  `undefined`
redis: `null`

在保留扩展性的情况下，无法解决这种不一致，只能增加 valid 自定义闭包。