### PR TITLE
set/get 默认值支持 promise

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -7,13 +7,13 @@ class Store {
     this.options = options;
   }
 
-  set(name, value, expire = null, options = null) {
+  async set(name, value, expire = null, options = null) {
     options = Object.assign({}, options, {
       ttl: expire,
     });
 
     if (typeof value === 'function') {
-      value = value();
+      value = await value();
     }
 
     return this.driver.set(name, value, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-cache",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Cache plugin for Egg",
   "eggPlugin": {
     "name": "cache"

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -26,6 +26,15 @@ describe('test/cache.test.js', () => {
     assert(value === 'bar');
   });
 
+  it('should set the value to memory', async () => {
+    await app.cache.set('foo', () => {
+      return Promise.resolve('bar');
+    });
+    const value = await app.cache.get('foo');
+
+    assert(value === 'bar');
+  });
+
   it('should cannot get value after expired', async () => {
     await app.cache.set('foo', 'bar', 1); // expires after 1 second
     const value = await app.cache.get('foo');


### PR DESCRIPTION
`get` 的默认值应该支持 `Promise`，否则下面语法糖没法实现。

如：

```js
app.cache.get('foo', () => {
  return Promise.resolve('bar');
});
```

大多数数据都是异步的，因此，实现获取异步数据再存储返回。
