### PR TITLE
 Memory driver multi  woker sync. ( memory config add `syncKey`, set …

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,35 @@
 'use strict';
+const pro = require('process');
+
+async function cacheSync (app,data) {
+  if (data.pid === pro.pid) {
+    return;
+  }
+
+  switch (data.act) {
+  case 0: app.cache.del(data); break;
+  case 1:
+    if (data.ttl > 0) {
+      app.cache.set(data);
+    } else {
+      app.cache.set(data);
+    }
+    break;
+  default: break;
+  }
+
+}
+
 
 module.exports = app => {
   app.cache = require('./lib/cache')(app);
+  const { default: defaultStore, stores } = app.config.cache;
+  if( defaultStore === 'memory' ) {
+    const key = ( stores.memory && stores.memory.syncKey ) ? stores.memory.syncKey : 'cacheSync';
+    process.on('message', msg => {
+      if (msg.action === key) {
+        cacheSync( app, msg.data );
+      }
+    });
+  }
 };

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,8 +2,8 @@
 
 const Store = require('./store');
 const manager = require('cache-manager');
-const pro = require('process');
 const drivers = Object.create(null);
+
 
 module.exports = app => {
 
@@ -32,39 +32,21 @@ module.exports = app => {
 
       const driver = manager.caching(options);
 
-      drivers[name] = new Store(driver, options);
+      drivers[name] = new Store(driver, options,app);
     }
 
     return drivers[name];
   };
 
-  const syncKey = ( stores.memory && stores.memory.syncKey ) ? stores.memory.syncKey : 'cacheSync';
-
   return {
     store,
     set: (...args) => {
-      let argsT = args;
-      if( defaultStore === 'memory' ) {
-        if(typeof(args[0]) === 'string'){
-          app.messenger.sendToApp(syncKey, { act: 1, pid: pro.pid, args: args });
-        } else {
-          argsT = args[0].args;
-        }
-      } 
-      return store(defaultStore).set(...argsT);      
+      return store(defaultStore).set(...args);      
     },
     get: (...args) => {
       return store(defaultStore).get(...args);
     },
     del: (...args) => {
-      let argsT = args;
-      if( defaultStore === 'memory' ) {
-        if( typeof(args[0]) === 'string' ) {
-          app.messenger.sendToApp(syncKey, { act: 0, pid: pro.pid, args: args });
-        } else {
-          argsT = args[0].args;
-        }
-      } 
       return store(defaultStore).del(...args);
     },
     has: (...args) => {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,7 @@
 
 const Store = require('./store');
 const manager = require('cache-manager');
-
+const pro = require('process');
 const drivers = Object.create(null);
 
 module.exports = app => {
@@ -38,15 +38,33 @@ module.exports = app => {
     return drivers[name];
   };
 
+  const syncKey = ( stores.memory && stores.memory.syncKey ) ? stores.memory.syncKey : 'cacheSync';
+
   return {
     store,
     set: (...args) => {
-      return store(defaultStore).set(...args);
+      let argsT = args;
+      if( defaultStore === 'memory' ) {
+        if(typeof(args[0]) === 'string'){
+          app.messenger.sendToApp(syncKey, { act: 1, pid: pro.pid, args: args });
+        } else {
+          argsT = args[0].args;
+        }
+      } 
+      return store(defaultStore).set(...argsT);      
     },
     get: (...args) => {
       return store(defaultStore).get(...args);
     },
     del: (...args) => {
+      let argsT = args;
+      if( defaultStore === 'memory' ) {
+        if( typeof(args[0]) === 'string' ) {
+          app.messenger.sendToApp(syncKey, { act: 0, pid: pro.pid, args: args });
+        } else {
+          argsT = args[0].args;
+        }
+      } 
       return store(defaultStore).del(...args);
     },
     has: (...args) => {

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,10 +1,13 @@
 'use strict';
+const pro = require('process');
 
 class Store {
-
-  constructor(driver, options) {
+  static syncKey = 'egg-cache:cacheSync'
+  constructor(driver, options,app) {
     this.driver = driver;
     this.options = options;
+    this.storeName = this.driver.store.name;
+    this.app = app;
   }
 
   async set(name, value, expire = null, options = null) {
@@ -19,6 +22,11 @@ class Store {
     return new Promise((resolve, reject) => {
       this.driver.set(name, value, options, err => {
         if (err) { return reject(err); }
+
+        if( this.storeName === 'memory' && options.isMemSync !== true ){
+          options.isMemSync = true;
+          this.app.messenger.sendToApp( Store.syncKey, { act: 1, pid: pro.pid, name,value,expire,options });
+        }
         resolve(value);
       });
     });
@@ -43,10 +51,14 @@ class Store {
     return defaultValue;
   }
 
-  del(name) {
+  del(name, isMemSync = null) {
     return new Promise((resolve, reject) => {
       this.driver.del(name, err => {
         if (err) { return reject(err); }
+
+        if( this.storeName === 'memory' && !isMemSync ){
+          this.app.messenger.sendToApp( Store.syncKey, { act: 0, pid: pro.pid, name, isMemSync: true });
+        }
         resolve();
       });
     });


### PR DESCRIPTION
 Memory driver multi  woker sync. ( memory config add `syncKey`, use for app.messenger action )
 > memory driver multi woker can't sync.
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
* memory driver

##### Description of change
<!-- Provide a description of the change below this comment. -->
使用内存驱动时，多个worker 之间没有同步.  
